### PR TITLE
eth/downloader: Fix ancientdb append error.

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -605,7 +605,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.
-		if origin >= frozen && frozen != 0 {
+		if origin >= frozen {
 			d.ancientLimit = 0
 			log.Info("Disabling direct-ancient mode", "origin", origin, "ancient", frozen-1)
 		} else if d.ancientLimit > 0 {


### PR DESCRIPTION
This may be a temporary fix.
Still, even if there are more changes, I think it's safer to disable direct ancient mode when `origin >= frozen` and `frozen==0` so this part would probably stay.