### PR TITLE
Add CI/CD pipelines for pushed tags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-* @this-is-iron @sb-anderson @gts2030 @gazzua @qqqeck @syjn99 @hoonyyhoon
+* @overprotocol/protocol-dev @this-is-iron

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Push image to Docker Hub
         run: |
-          docker push overfoundation/kairos:$DOCKER_TAG
+          docker push overfoundation/kairos:${{ steps.set-docker-tag.outputs.docker_tag }}

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login docker hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -1,0 +1,43 @@
+name: Build Docker images push to Docker Hub
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      version_name:
+        required: true
+        type: string
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    outputs:
+      docker_tag: ${{ steps.set-docker-tag.outputs.docker_tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Git config
+        run: |
+          git config --global --add safe.directory /__w/kairos/kairos
+
+      - name: Set Docker Tag
+        id: set-docker-tag
+        run: |
+          echo "docker_tag=${{ inputs.version_name }}_${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+
+      - name: Build images
+        run: |
+          export DOCKER_TAG=${{ steps.set-docker-tag.outputs.docker_tag }}
+          docker build --tag kairos:$DOCKER_TAG .
+          docker image tag kairos:$DOCKER_TAG overfoundation/kairos:$DOCKER_TAG
+
+      - name: Login docker hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub
+        run: |
+          docker push overfoundation/kairos:$DOCKER_TAG

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -13,10 +13,14 @@ on:
 jobs:
   build-images:
     runs-on: ubuntu-latest
-    outputs:
-      docker_tag: ${{ steps.set-docker-tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Login docker hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: actions/checkout@v4
       - name: Git config
         run: |
           git config --global --add safe.directory /__w/kairos/kairos
@@ -31,12 +35,6 @@ jobs:
           export DOCKER_TAG=${{ steps.set-docker-tag.outputs.docker_tag }}
           docker build --tag kairos:$DOCKER_TAG .
           docker image tag kairos:$DOCKER_TAG overfoundation/kairos:$DOCKER_TAG
-
-      - name: Login docker hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push image to Docker Hub
         run: |

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -44,3 +44,8 @@ jobs:
       - name: Push image to Docker Hub
         run: |
           docker push overfoundation/kairos:${{ steps.set-docker-tag.outputs.docker_tag }}
+
+      - name: Push latest image to Docker Hub
+        if: ${{ inputs.tag_name == 'stable' }}
+        run: |
+          docker push overfoundation/kairos:latest

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -9,6 +9,11 @@ on:
       version_name:
         required: true
         type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   build-images:

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,75 @@
+name: Build binaries
+
+on:
+  workflow_call:
+    inputs:
+      build-type:
+        required: true
+        type: string
+      tag_name:
+        required: true
+        type: string
+      version_name:
+        required: true
+        type: string
+
+jobs:
+  build-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Git config
+        run: |
+          git config --global --add safe.directory /__w/kairos/kairos
+
+      - name: Build ${{ inputs.build-type }}
+        run: |
+          if [[ "${{ inputs.build-type }}" == *"darwin"* ]]; then
+            export GOOS=darwin
+          elif [[ "${{ inputs.build-type }}" == *"windows"* ]]; then
+            export GOOS=windows
+          else
+            export GOOS=linux
+          fi
+
+          if [[ "${{ inputs.build-type }}" == *"arm64"* ]]; then
+            export GOARCH=arm64
+          else
+            export GOARCH=amd64
+          fi
+
+          if [[ "${{ inputs.build-type }}" == *"windows"* ]]; then
+            go build -ldflags="-s -w" -trimpath -o ./build/bin/geth.exe ./cmd/geth
+            go build -ldflags="-s -w" -trimpath -o ./build/bin/bootnode.exe ./cmd/bootnode
+          elif [[ "${{ inputs.build-type }}" == *"linux"* ]]; then
+            go build -ldflags="-s -extldflags '-Wl,-z,stack-size=0x800000'" -trimpath -o ./build/bin/geth ./cmd/geth
+            go build -ldflags="-s -extldflags '-Wl,-z,stack-size=0x800000'" -trimpath -o ./build/bin/bootnode ./cmd/bootnode
+          else
+            go build -ldflags="-s -w" -trimpath -o ./build/bin/geth ./cmd/geth
+            go build -ldflags="-s -w" -trimpath -o ./build/bin/bootnode ./cmd/bootnode
+          fi
+
+      - name: Make dist directory
+        run: |
+          mkdir -p dist
+          mkdir -p dist/${{ github.sha }}
+
+      - name: Zip artifact (Windows)
+        if: ${{ inputs.build-type == 'windows_amd64' }}
+        run: |
+          zip -j dist/${{ github.sha }}/kairos_${{ inputs.build-type }}.zip \
+            build/bin/geth.exe \
+            build/bin/bootnode.exe
+
+      - name: Zip artifact (Non-Windows)
+        if: ${{ inputs.build-type != 'windows_amd64' }}
+        run: |
+          zip -j dist/${{ github.sha }}/kairos_${{ inputs.build-type }}.zip \
+            build/bin/geth \
+            build/bin/bootnode
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kairos_${{ github.sha }}_${{ inputs.build-type }}
+          path: dist/${{ github.sha }}/kairos_${{ inputs.build-type }}.zip

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -110,6 +110,9 @@ jobs:
     with:
       tag_name: ${{ needs.extract-version.outputs.tag_name }}
       version_name: ${{ needs.extract-version.outputs.version_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   create-release:
     needs: [build, extract-version]

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           path: dist/${{ github.sha }}
 
+      - name: Flatten directory structure
+        run: |
+          find dist/${{ github.sha }} -name '*.zip' -exec mv {} dist/${{ github.sha }}/ \;
+          find dist/${{ github.sha }} -mindepth 1 -type d -delete
+
       - name: Upload to S3
         run: |
           aws s3 cp dist/${{ github.sha }} \
@@ -87,6 +92,11 @@ jobs:
       - name: Upload updated latest.yml to S3
         run: |
           aws s3 cp latest.yml s3://${{ secrets.AWS_BUCKET_NAME }}/latest/latest.yml --acl public-read
+
+      - name: Flatten directory structure
+        run: |
+          find dist/${{ github.sha }} -name '*.zip' -exec mv {} dist/${{ github.sha }}/ \;
+          find dist/${{ github.sha }} -mindepth 1 -type d -delete
 
       - name: Upload to S3
         run: |

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -1,0 +1,159 @@
+name: Build with tag
+
+on:
+  push:
+    tags:
+      - "v*_*" # Format: v<major>.<minor>.<patch>[_<stable|beta|dev>]
+
+permissions:
+  contents: write
+
+jobs:
+  extract-version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.extract.outputs.tag_name }}
+      version_name: ${{ steps.extract.outputs.version_name }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract tag name, version
+        id: extract
+        run: |
+          full_tag="${{ github.ref_name }}"
+          version_name="${full_tag%%_*}"
+          tag_name="${full_tag#*_}"
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+          echo "version_name=$version_name" >> $GITHUB_OUTPUT
+
+  build:
+    needs: extract-version
+    strategy:
+      matrix:
+        symbol-list: [darwin_amd64, darwin_arm64, windows_amd64, linux_amd64]
+    uses: ./.github/workflows/_build.yml
+    with:
+      build-type: ${{ matrix.symbol-list }}
+      tag_name: ${{ needs.extract-version.outputs.tag_name }}
+      version_name: ${{ needs.extract-version.outputs.version_name }}
+
+  upload-aws:
+    needs: [build, extract-version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/${{ github.sha }}
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp dist/${{ github.sha }} \
+            s3://${{ secrets.AWS_BUCKET_NAME }}/${{ needs.extract-version.outputs.version_name }}/${{ needs.extract-version.outputs.tag_name }} \
+            --recursive --exclude "*" --include "*.zip" --acl public-read
+
+  upload-aws-latest:
+    needs: [build, extract-version]
+    runs-on: ubuntu-latest
+    if: ${{ needs.extract-version.outputs.tag_name == 'stable' }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/${{ github.sha }}
+
+      - name: Download latest.yml from S3
+        run: |
+          aws s3 cp s3://${{ secrets.AWS_BUCKET_NAME }}/latest/latest.yml latest.yml
+
+      - name: Update latest.yml file for kairos
+        run: |
+          echo "Updating kairos version and tag in latest.yml"
+          yq eval '.kairos.version = "${{ needs.extract-version.outputs.version_name }}" | .kairos.tag = "${{ needs.extract-version.outputs.tag_name }}"' -i latest.yml
+
+      - name: Upload updated latest.yml to S3
+        run: |
+          aws s3 cp latest.yml s3://${{ secrets.AWS_BUCKET_NAME }}/latest/latest.yml --acl public-read
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp dist/${{ github.sha }} \
+            s3://${{ secrets.AWS_BUCKET_NAME }}/latest/kairos \
+            --recursive --exclude "*" --include "*.zip" --acl public-read
+
+  docker:
+    needs: [extract-version]
+    uses: ./.github/workflows/_build-docker.yml
+    with:
+      tag_name: ${{ needs.extract-version.outputs.tag_name }}
+      version_name: ${{ needs.extract-version.outputs.version_name }}
+
+  create-release:
+    needs: [build, extract-version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Generate release changelog"
+        id: changelog
+        run: |
+          git fetch --tags
+          prev_tag=$(git tag --sort=-version:refname | grep -e "^v[0-9.]*$" | head -n 1)
+          echo "previous release: $prev_tag"
+          if [ "$prev_tag" ]; then
+            changelog=$(git log --oneline --no-decorate $prev_tag..HEAD)
+          else
+            changelog=$(git log --oneline --no-decorate)
+          fi
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo " - ${changelog//$'\n'/$'\n' - }" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**/*.zip
+          draft: true
+          prerelease: false
+          body: |
+            ### Changes
+            ${{ steps.changelog.outputs.changelog }}
+
+            ### Release Artifacts
+            Please read through our official [documentation](https://docs.over.network/) for setup instructions.
+            | Release File  | Description |
+            | ------------- | ------------- |
+            | [kairos_windows_amd64.zip](https://github.com/overprotocol/kairos/releases/download/${{ github.ref_name }}/kairos_windows_amd64.zip) | kairos executables for windows/amd64 |
+            | [kairos_linux_amd64.zip](https://github.com/overprotocol/kairos/releases/download/${{ github.ref_name }}/kairos_linux_amd64.zip) | kairos executables for linux/amd64 |
+            | [kairos_darwin_amd64.zip](https://github.com/overprotocol/kairos/releases/download/${{ github.ref_name }}/kairos_darwin_amd64.zip) | kairos executables for macos/amd64 |
+            | [kairos_darwin_arm64.zip](https://github.com/overprotocol/kairos/releases/download/${{ github.ref_name }}/kairos_darwin_arm64.zip) | kairos executables for macos/arm64 |
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  clean:
+    needs: [create-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up
+        run: |
+          rm -rf dist
+          rm -rf build/bin


### PR DESCRIPTION
- Changed `CODEOWNERS` using organization team
- Add `tag-build.yml`, which will do following:
  - Build by `go build`
  - Upload objects into AWS S3 bucket
  - Build Docker images and push to Docker hub
  - Create release, which contains artifacts that were built.
  - if `tag_name` is equal to `stable`, upload those artifacts as `latest`.