### PR TITLE
Fix transaction max size to 32KB

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -46,14 +46,14 @@ const (
 	// txSlotSize is used to calculate how many data slots a single transaction
 	// takes up based on its size. The slots are used as DoS protection, ensuring
 	// that validating a new transaction remains a constant operation (in reality
-	// O(maxslots), where max slots are 4 currently).
+	// O(maxslots), where max slots are 1 currently).
 	txSlotSize = 32 * 1024
 
 	// txMaxSize is the maximum size a single transaction can have. This field has
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 4 * txSlotSize // 128KB
+	txMaxSize = 1 * txSlotSize // 32KB
 )
 
 var (

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -46,14 +46,14 @@ const (
 	// txSlotSize is used to calculate how many data slots a single transaction
 	// takes up based on its size. The slots are used as DoS protection, ensuring
 	// that validating a new transaction remains a constant operation (in reality
-	// O(maxslots), where max slots are 1 currently).
-	txSlotSize = 32 * 1024
+	// O(maxslots), where max slots are 4 currently).
+	txSlotSize = 8 * 1024
 
 	// txMaxSize is the maximum size a single transaction can have. This field has
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 1 * txSlotSize // 32KB
+	txMaxSize = 4 * txSlotSize // 32KB
 )
 
 var (


### PR DESCRIPTION
### Problem Statement

The current transaction size limit of 128KB places unnecessary strain on the protocol and introduces potential inefficiencies. Reducing the transaction size limit addresses two key concerns:

- DoS Attack Vector: Large transaction sizes could be exploited to execute DoS attacks, overwhelming network resources.
- Mempool Size Management: Large transactions unnecessarily inflate mempool size, making it harder to manage and increasing memory consumption.

### Key Considerations

- This is not a change that affects consensus. It's only related with node client's implementation details.
- The DoS mitigation mechanisms in the transaction pool, designed for a 32KB structure, should remain effective under this update.
- With the new limit, each transaction will occupy only one slot in the mempool, ensuring efficient resource utilization.
- While we are considering introducing explicit transaction size limits as part of the block validation logic, the current block gas limit and gas pricing mechanisms already serve as indirect constraints to mitigate issues related to oversized transactions.


### Related PR
This change complements the rollback of gas price calculations for tx data in PR: [#27](https://github.com/overprotocol/kairos/pull/27).

