### PR TITLE
Pin ubuntu version to `22.04` in github workflow

### DIFF
--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -17,7 +17,12 @@ on:
 
 jobs:
   build-images:
-    runs-on: ubuntu-latest
+    # `ubuntu-latest` uses `ubuntu-24.04` from 2025-01-10,
+    # which causes dynamic linking issues with glibc.
+    # Temporarily using `ubuntu-22.04` until the issue is resolved.
+    # Related links:
+    # - https://github.com/ethereum/go-ethereum/issues/30115
+    runs-on: ubuntu-22.04
     steps:
       - name: Login docker hub
         uses: docker/login-action@v3.1.0

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -15,7 +15,12 @@ on:
 
 jobs:
   build-binaries:
-    runs-on: ubuntu-latest
+    # `ubuntu-latest` uses `ubuntu-24.04` from 2025-01-10,
+    # which causes dynamic linking issues with glibc.
+    # Temporarily using `ubuntu-22.04` until the issue is resolved.
+    # Related links:
+    # - https://github.com/ethereum/go-ethereum/issues/30115
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Git config


### PR DESCRIPTION
https://github.com/actions/runner-images/pull/11332

```
> file geth
geth: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=61db86e8ee22849c130c11687bfb14d3449f3264, for GNU/Linux 3.2.0, stripped
```

Since 2025-01-10, `ubuntu-latest` uses `ubuntu-24.04`, which causes issues when dynamically linking with `glibc`. This PR temporarily pins our runner version into `ubuntu-22.04`.

