### PR TITLE
Debug/ignored upnp issue

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/huin/goupnp"
 	"github.com/huin/goupnp/dcps/internetgateway1"
 	"github.com/huin/goupnp/dcps/internetgateway2"
@@ -80,6 +81,7 @@ func (n *upnp) ExternalIP() (addr net.IP, err error) {
 }
 
 func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) (uint16, error) {
+	log.Debug("AddMapping", "protocol", protocol, "extport", extport, "intport", intport, "desc", desc, "lifetime", lifetime)
 	ip, err := n.internalAddress()
 	if err != nil {
 		return 0, nil // TODO: Shouldn't we return the error?
@@ -90,6 +92,7 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	err = n.withRateLimit(func() error {
 		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 	})
+	log.Debug("AddPortMapping", "err", err)
 	if err == nil {
 		return uint16(extport), nil
 	}
@@ -99,6 +102,7 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 		if err == nil {
 			extport = int(p)
 		}
+		log.Debug("addAnyPortMapping", "err", err)
 		return err
 	})
 }

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/huin/goupnp"
 	"github.com/huin/goupnp/dcps/internetgateway1"
 	"github.com/huin/goupnp/dcps/internetgateway2"
@@ -81,7 +80,6 @@ func (n *upnp) ExternalIP() (addr net.IP, err error) {
 }
 
 func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) (uint16, error) {
-	log.Debug("AddMapping", "protocol", protocol, "extport", extport, "intport", intport, "desc", desc, "lifetime", lifetime)
 	ip, err := n.internalAddress()
 	if err != nil {
 		return 0, nil // TODO: Shouldn't we return the error?
@@ -89,10 +87,13 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	protocol = strings.ToUpper(protocol)
 	lifetimeS := uint32(lifetime / time.Second)
 
+	if n.service == "IGDv1-IP1" {
+		n.client.DeletePortMapping("", uint16(extport), strings.ToUpper(protocol))
+	}
+
 	err = n.withRateLimit(func() error {
 		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 	})
-	log.Debug("AddPortMapping", "err", err)
 	if err == nil {
 		return uint16(extport), nil
 	}
@@ -102,7 +103,6 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 		if err == nil {
 			extport = int(p)
 		}
-		log.Debug("addAnyPortMapping", "err", err)
 		return err
 	})
 }

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	portMapDuration        = 10 * time.Minute
-	portMapRefreshInterval = 8 * time.Minute
+	portMapRefreshInterval = 9 * time.Minute
 	portMapRetryInterval   = 5 * time.Minute
 	extipRetryInterval     = 2 * time.Minute
 )

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	portMapDuration        = 10 * time.Minute
-	portMapRefreshInterval = 9 * time.Minute
+	portMapRefreshInterval = 8 * time.Minute
 	portMapRetryInterval   = 5 * time.Minute
 	extipRetryInterval     = 2 * time.Minute
 )

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -157,10 +157,6 @@ func (srv *Server) portMappingLoop() {
 				log := newLogger(m.protocol, external, m.port)
 
 				log.Trace("Attempting port mapping")
-				err := srv.NAT.DeleteMapping(m.protocol, external, m.port)
-				if err != nil {
-					log.Debug("Couldn't delete port mapping", "err", err)
-				}
 
 				p, err := srv.NAT.AddMapping(m.protocol, external, m.port, m.name, portMapDuration)
 				if err != nil {

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -157,6 +157,11 @@ func (srv *Server) portMappingLoop() {
 				log := newLogger(m.protocol, external, m.port)
 
 				log.Trace("Attempting port mapping")
+				err := srv.NAT.DeleteMapping(m.protocol, external, m.port)
+				if err != nil {
+					log.Debug("Couldn't delete port mapping", "err", err)
+				}
+
 				p, err := srv.NAT.AddMapping(m.protocol, external, m.port, m.name, portMapDuration)
 				if err != nil {
 					log.Debug("Couldn't add port mapping", "err", err)


### PR DESCRIPTION
Some routers using "UPnP IGD v1" ignore the port mapping request when previous mapping request's lifetime is left.

To handle this, manual delete & add is required.