### PR TITLE
fix: reduce skewed gas prices

### DIFF
--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -238,11 +238,11 @@ func TestSuggestTipCap(t *testing.T) {
 		fork   *big.Int // London fork number
 		expect *big.Int // Expected gasprice suggestion
 	}{
-		{nil, big.NewInt(params.MinimumBaseFee + params.GWei*int64(30))},
-		{big.NewInt(0), big.NewInt(params.MinimumBaseFee)},                          // Fork point in genesis
-		{big.NewInt(1), big.NewInt(params.MinimumBaseFee)},                          // Fork point in first block
-		{big.NewInt(32), big.NewInt(params.MinimumBaseFee + params.GWei*int64(29))}, // Fork point in last block
-		{big.NewInt(33), big.NewInt(params.MinimumBaseFee + params.GWei*int64(30))}, // Fork point in the future
+		{nil, big.NewInt((params.MinimumBaseFee + params.GWei*int64(30)) * 8 / 10)},
+		{big.NewInt(0), big.NewInt((params.MinimumBaseFee) * 8 / 10)},                          // Fork point in genesis
+		{big.NewInt(1), big.NewInt((params.MinimumBaseFee) * 8 / 10)},                          // Fork point in first block
+		{big.NewInt(32), big.NewInt((params.MinimumBaseFee + params.GWei*int64(29)) * 8 / 10)}, // Fork point in last block
+		{big.NewInt(33), big.NewInt((params.MinimumBaseFee + params.GWei*int64(30)) * 8 / 10)}, // Fork point in the future
 	}
 	for _, c := range cases {
 		backend := newTestBackend(t, c.fork, nil, false)


### PR DESCRIPTION
# Main Changes
1. Added tip adjustment logic based on block congestion (gas usage)

- We now sample each block’s gasUsed / gasLimit ratio to automatically lower or raise the tip if the network is underutilized or congested.
-  Specifically, when averageRatio <= 0.5, we set a congestionFactor of 0.8, and if averageRatio >= 0.9, we set 1.2. For the middle range, we interpolate linearly between these values.

# Effects and Benefits
- In cases where there are few transactions in a block or only a small number of very high-tip transactions, the oracle will reduce the suggested tip based on measured block congestion. This prevents suggesting unnecessarily high gas prices.

- Conversely, if most blocks are near capacity, the tip will increase so transactions can be included quickly during heavy network usage.